### PR TITLE
Fix STS import issue:

### DIFF
--- a/complete/settings.gradle
+++ b/complete/settings.gradle
@@ -1,2 +1,1 @@
-rootProject.name = 'gs-yarn-testing'
 include 'gs-yarn-testing-client','gs-yarn-testing-appmaster','gs-yarn-testing-container','gs-yarn-testing-dist'

--- a/initial/settings.gradle
+++ b/initial/settings.gradle
@@ -1,2 +1,1 @@
-rootProject.name = 'gs-yarn-testing'
 include 'gs-yarn-testing-client','gs-yarn-testing-appmaster','gs-yarn-testing-container','gs-yarn-testing-dist'


### PR DESCRIPTION
Changing project name in settings.gradle causes errors (name conflicts) 
in gs import wizard in STS.

See https://build.spring.io/browse/IDE-GSGUIDES-JOB1-3/test/case/163033432

Note that this really only partially fixes the problem STS has with this guide. Subprojects still have clashing names and will cause problems if user asks the wizard to import both 'initial' and 'complete' projects, because the initial and complete projects have identically named subprojects.

I don't know a good solution to the problem with the subprojects. The only thing I can think of that would work is that initial and complete hierarchies rename all the subprojects to XXX-initial and XXX-complete to keep them separate, but that seems not very nice.

Anyhow... with the changes that I made at least the initial OR complete projects can be imported provided that only one of them is selected for import in the wizard at the same time.